### PR TITLE
Xml for post data was invalid, Reference to undeclared entity 'Atilde'

### DIFF
--- a/xero.php
+++ b/xero.php
@@ -1267,8 +1267,7 @@ class ArrayToXML
             } else {
 
                 // add single node.
-                $value = htmlentities( $value );
-                $xml->addChild( $key, $value );
+                $xml->$key = $value;
             }
         }
 


### PR DESCRIPTION
When sending international characters this messages pops up "Xml for post data was invalid, Reference to undeclared entity 'Atilde'"

According to this Stackoverflow http://stackoverflow.com/questions/552957/, addChild() does not escape xml entities, whereas setting directly via $xml->$key does escape entities, removes the need to try and escape them ourselves first, as the current htmlentities() call doesn't do a good job of all xml entities

Also see this discussion
https://community.xero.com/developer/discussion/32311/
